### PR TITLE
Allow ArrayInterface 6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ Static = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 SuiteSparse = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 
 [compat]
-ArrayInterface = "7"
+ArrayInterface = "6, 7"
 Compat = "4"
 IfElse = "0.1"
 SnoopPrecompile = "1"


### PR DESCRIPTION
I realized that it is just fine to allow this, as long as the proper extensions are brought in. This should help the upgrade.