### PR TITLE
allow Static.jl v0.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ ArrayInterface = "7"
 Compat = "4"
 IfElse = "0.1"
 SnoopPrecompile = "1"
-Static = "0.8"
+Static = "0.7, 0.8"
 Requires = "1"
 julia = "1.6"
 


### PR DESCRIPTION
Some packages in the ecosystem haven't updated to v0.8 of Static.jl yet. If there is a chance that StaticArrayInterface.jl works with v0.7 of Static.jl, it would help us a lot.
I haven't checked all the code, so please let me know if there is an issue with the older version of Static.jl.