### PR TITLE
inline sub_axes_map(T::Type{<:SubArray}))

### DIFF
--- a/src/dimensions.jl
+++ b/src/dimensions.jl
@@ -32,9 +32,9 @@ function _permdims(::Type{<:PermutedDimsArray{<:Any,<:Any,I1,I2}}) where {I1,I2}
     (map(static, I1), map(static, I2))
 end
 
-# Base will sometomes demote statically known slices in `SubArray` to `OneTo{Int}` so we
+# Base will sometimes demote statically known slices in `SubArray` to `OneTo{Int}` so we
 # provide the parent mapping to check for static size info
-function sub_axes_map(@nospecialize(T::Type{<:SubArray}))
+@inline function sub_axes_map(@nospecialize(T::Type{<:SubArray}))
     map(Base.Fix1(_sub_axis_map, T), map_indices_info(IndicesInfo(T)))
 end
 function _sub_axis_map(@nospecialize(T::Type{<:SubArray}), x::Tuple{StaticInt{index},Any,Any}) where {index}


### PR DESCRIPTION
This fixes some serious performance issues for us in Trixi.jl increasing the runtime up to two orders of magnitude.

Another option would be to remove the `@nospecialize` in the method definition I changed here.

It is hard to provide a good test for it since it is deeply nested, involves LoopVectorization.jl, and is related to nasty issues such as https://github.com/JuliaLang/julia/issues/35800 and https://github.com/JuliaLang/julia/issues/45388

It would be great if we could merge this and make a new release of StaticArrayInterface.jl.

CC @sloede
