### PR TITLE
move Requires import to within the extension check

### DIFF
--- a/src/StaticArrayInterface.jl
+++ b/src/StaticArrayInterface.jl
@@ -486,8 +486,8 @@ include("indexing.jl")
 include("stridelayout.jl")
 include("broadcast.jl")
 
-import Requires
 @static if !isdefined(Base, :get_extension)
+    import Requires
     function __init__()
         Requires.@require StaticArrays = "90137ffa-7385-5640-81b9-e52037218182" begin include("../ext/StaticArrayInterfaceStaticArraysExt.jl") end
         Requires.@require OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881" begin include("../ext/StaticArrayInterfaceOffsetArraysExt.jl") end

--- a/src/StaticArrayInterface.jl
+++ b/src/StaticArrayInterface.jl
@@ -488,6 +488,9 @@ include("broadcast.jl")
 
 @static if !isdefined(Base, :get_extension)
     import Requires
+end
+
+@static if !isdefined(Base, :get_extension)
     function __init__()
         Requires.@require StaticArrays = "90137ffa-7385-5640-81b9-e52037218182" begin include("../ext/StaticArrayInterfaceStaticArraysExt.jl") end
         Requires.@require OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881" begin include("../ext/StaticArrayInterfaceOffsetArraysExt.jl") end


### PR DESCRIPTION
No need to import this if it isn't going to be used.