### PR TITLE
Fix multi-dimensional boolean indexing for Julia 1.12 compatibility

### DIFF
--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -69,7 +69,14 @@ end
 @inline (ima::IndexedMappedArray{A})(idx::I, d::StaticInt{D}) where {A,I,D} = to_index(lazy_axes(ima.a, d), idx)
 @inline function (ima::IndexedMappedArray{A})(idx::AbstractArray{Bool}, dims::Tuple) where {A}
     if (last(dims) == ndims(A)) && (IndexStyle(A) isa IndexLinear)
-        return LogicalIndex{Int}(idx)
+        # Match Base.to_indices behavior for trailing boolean arrays.
+        # Julia >= 1.12 uses LogicalIndex(idx) which gives CartesianIndex{N} for N-D booleans.
+        # Julia < 1.12 uses LogicalIndex{Int}(idx) which gives linear indices.
+        @static if VERSION >= v"1.12-"
+            return LogicalIndex(idx)
+        else
+            return LogicalIndex{Int}(idx)
+        end
     else
         return LogicalIndex(idx)
     end


### PR DESCRIPTION
## Summary

- Fix `static_to_indices` to match `Base.to_indices` behavior across Julia versions for multi-dimensional boolean array indices
- Julia >= 1.12 changed `Base.to_indices` to return `LogicalIndex{CartesianIndex{N}}` for N-D boolean arrays, while Julia < 1.12 returns `LogicalIndex{Int}` (linear indices) for trailing boolean arrays on `IndexLinear` arrays
- Uses `@static if VERSION >= v"1.12-"` to select the correct `LogicalIndex` type, ensuring compatibility with both Julia 1.10 and 1.12+

## Details

On Julia 1.12, the test at `test/indexing.jl:61` was failing:

```
to_indices: Test Failed at test/indexing.jl:61
  Expression: static_to_indices(a, (1, fill(true, 2, 2))) == Base.to_indices(a, (1, fill(true, 2, 2)))
   Evaluated: (1, [1, 2, 3, 4]) == (1, CartesianIndex{2}[CartesianIndex(1, 1), CartesianIndex(2, 1), CartesianIndex(1, 2), CartesianIndex(2, 2)])
```

The root cause: `Base.LogicalIndex` constructors return different element types based on dimensionality:
- `LogicalIndex(::AbstractVector{Bool})` → `LogicalIndex{Int}` (linear indices)
- `LogicalIndex(::AbstractArray{Bool})` → `LogicalIndex{CartesianIndex{N}}` (Cartesian indices)

`Base.to_indices` previously forced `LogicalIndex{Int}` for trailing boolean arrays on `IndexLinear` arrays, but Julia 1.12 changed this to use `LogicalIndex(idx)` which gives `CartesianIndex{N}` for N-D booleans.

The fix uses `@static if VERSION >= v"1.12-"` to match Base's behavior on each Julia version.

**Note:** The documentation build failure and `VectorizationBase.jl/Interface/1.6` failure are pre-existing issues unrelated to this change.

## Test plan

- [x] All tests pass on Julia 1.12.4 with `JULIA_DEPWARN=error`
- [x] Version-gated to preserve Julia 1.10 behavior
- [x] Verified `static_to_indices` output matches `Base.to_indices` for the affected case on Julia 1.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)