### PR TITLE
Fix for Static.jl v1.4

### DIFF
--- a/src/stridelayout.jl
+++ b/src/stridelayout.jl
@@ -435,7 +435,7 @@ function dense_dims(@nospecialize T::Type{<:Base.ReshapedArray})
     end
 end
 
-is_dense(A) = all(dense_dims(A)) ? True() : False()
+is_dense(A) = all(Bool, dense_dims(A)) ? True() : False()
 
 """
     known_strides(::Type{T}) -> Tuple

--- a/src/stridelayout.jl
+++ b/src/stridelayout.jl
@@ -428,7 +428,7 @@ function dense_dims(@nospecialize T::Type{<:Base.ReshapedArray})
     d = dense_dims(parent_type(T))
     if d === nothing
         return nothing
-    elseif all(d)
+    elseif all(Bool, d)
         return ntuple(Compat.Returns(True()), StaticInt(ndims(T)))
     else
         return ntuple(Compat.Returns(False()), StaticInt(ndims(T)))


### PR DESCRIPTION
Static.jl removed `Base.all` on tuples of `Static.True()`/`Static.False()` in https://github.com/SciML/Static.jl/pull/163, which breaks StaticArrayInterface.jl, see https://github.com/SciML/Static.jl/pull/163#issuecomment-4339683224. This fixes it again.
See also https://github.com/JuliaSIMD/StrideArraysCore.jl/pull/53.
CC @ChrisRackauckas, @efaulhaber